### PR TITLE
Fix #15. Add type time to DateTime

### DIFF
--- a/src/components/date-time-iso/date-time-iso.jsx
+++ b/src/components/date-time-iso/date-time-iso.jsx
@@ -20,6 +20,8 @@ export default function DateTimeIso({
     dateString = `${iso.get('date')} ${iso.get('HH')}:${iso.get('MM')}`;
   } else if (hour) {
     dateString = `${iso.get('date')} ${iso.get('HH')}`;
+  } else {
+    dateString = `${iso.get('date')}`;
   }
 
   return (

--- a/src/components/date-time/date-time-formats.js
+++ b/src/components/date-time/date-time-formats.js
@@ -11,6 +11,17 @@ export default {
       year: 'numeric',
     },
   },
+  time: {
+    numeric: {
+      hour: 'numeric',
+      minute: 'numeric',
+      second: 'numeric',
+    },
+    human: {
+      hour: 'numeric',
+      minute: 'numeric',
+    },
+  },
   relative: {
     numeric: {
       style: 'numeric',

--- a/src/components/date-time/date-time.examples.md
+++ b/src/components/date-time/date-time.examples.md
@@ -14,6 +14,14 @@ Example showing numeric format for date:
 
 	<DateTime value={ 19234829847289 } format="numeric" type="date" />
 
+Example showing human format for time:
+
+	<DateTime value={ new Date() } format="human" type="time" />
+
+Example showing numeric format for time:
+
+	<DateTime value={ new Date() } format="numeric" type="time" />
+
 Example showing human format for relative:
 
 	<DateTime value={ (new Date() - 24 * 60 * 60 * 1000) } format="human" type="relative" />

--- a/src/components/date-time/date-time.jsx
+++ b/src/components/date-time/date-time.jsx
@@ -1,8 +1,11 @@
 import React from 'react';
-import { FormattedDate, FormattedRelative } from 'react-intl';
+import { FormattedDate, FormattedTime, FormattedRelative } from 'react-intl';
 import DateTimeIso from '../date-time-iso/date-time-iso';
 import formats from './date-time-formats';
 
+/**
+  This is the `<DateTime /> component`
+*/
 function DateTime({
   value,
   format,
@@ -17,6 +20,7 @@ function DateTime({
   const components = {
     date: FormattedDate,
     relative: FormattedRelative,
+    time: FormattedTime,
   };
   const Component = components[type];
 
@@ -42,12 +46,11 @@ DateTime.propTypes = {
     React.PropTypes.number,
     React.PropTypes.instanceOf(Date),
   ]).isRequired,
-  type: React.PropTypes.oneOf(['date', 'relative']),
+  type: React.PropTypes.oneOf(['date', 'time', 'relative']),
 };
 
 
 DateTime.defaultProps = {
-  format: 'numeric',
   iso: false,
   type: 'date',
 };

--- a/src/components/development/development.jsx
+++ b/src/components/development/development.jsx
@@ -42,6 +42,9 @@ function getDirection(value) {
   return 'neutral';
 }
 
+/**
+  This is the `<Development /> component`
+*/
 export default function Development({
   value,
   decimals,

--- a/src/components/percent/percent.jsx
+++ b/src/components/percent/percent.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Number from '../number/number';
 
 /**
-  This is the Percent component
+  This is the `<Percent /> component`
 */
 export default function Percent({
   decimals,

--- a/test/components/date-time-iso.test.js
+++ b/test/components/date-time-iso.test.js
@@ -9,7 +9,7 @@ describe('<DateTimeIso />', () => {
 
   it('should show only the date if neither hour, minute or second is supplied', () => {
     component = shallow(<DateTimeIso value={ defaultTimestamp } />);
-    expect(component.text().split(' ')[0].match(/^[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]$/)).to.not.equal(null);
+    expect(component.text().match(/^[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]$/)).to.not.equal(null);
   });
 
   it('should show HH if prop hour is supplied', () => {

--- a/test/components/date-time-iso.test.js
+++ b/test/components/date-time-iso.test.js
@@ -7,6 +7,11 @@ describe('<DateTimeIso />', () => {
   let component;
   const defaultTimestamp = 1461756108561;
 
+  it('should show only the date if neither hour, minute or second is supplied', () => {
+    component = shallow(<DateTimeIso value={ defaultTimestamp } />);
+    expect(component.text().split(' ')[0].match(/^[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]$/)).to.not.equal(null);
+  });
+
   it('should show HH if prop hour is supplied', () => {
     component = shallow(<DateTimeIso value={ defaultTimestamp } hour="numeric" />);
     expect(component.text().split(' ')[1].match(/^[0-9][0-9]$/)).to.not.equal(null);

--- a/test/components/date-time.test.js
+++ b/test/components/date-time.test.js
@@ -8,52 +8,83 @@ describe('<DateTime />', () => {
   const defaultTimestamp = 1461756108561;
 
   describe('with type="date"', () => {
-    beforeEach(() => {
-      component = shallow(<DateTime value={ defaultTimestamp } type="date" />);
+    describe('and format="numeric"', () => {
+      beforeEach(() => {
+        component = shallow(<DateTime value={ defaultTimestamp } format="numeric" type="date" />);
+      });
+
+      it('should wrap a FormattedDate', () => {
+        expect(component.type().name).to.equal('FormattedDate');
+      });
+
+      it('should set year, month and day to "numeric"', () => {
+        expect(component.prop('year')).to.equal('numeric');
+        expect(component.prop('month')).to.equal('numeric');
+        expect(component.prop('day')).to.equal('numeric');
+      });
     });
 
-    it('should wrap a FormattedDate', () => {
-      expect(component.type().name).to.equal('FormattedDate');
-    });
-
-    it('should set year, month and day to "numeric"', () => {
-      expect(component.prop('year')).to.equal('numeric');
-      expect(component.prop('month')).to.equal('numeric');
-      expect(component.prop('day')).to.equal('numeric');
-    });
-
-    it('should set month="long" when format="human"', () => {
-      component = shallow(<DateTime value={ defaultTimestamp } format="human" />);
-      expect(component.prop('month')).to.equal('long');
+    describe('and format="human"', () => {
+      it('should set month="long" when format="human"', () => {
+        component = shallow(<DateTime value={ defaultTimestamp } format="human" type="date" />);
+        expect(component.prop('month')).to.equal('long');
+      });
     });
 
     describe('and iso set', () => {
-      beforeEach(() => {
-        component = shallow(<DateTime value={ defaultTimestamp } type="date" iso />);
-      });
-
       it('should wrap a DateTimeIso', () => {
+        component = shallow(<DateTime value={ defaultTimestamp } type="date" iso />);
         expect(component.type().name).to.equal('DateTimeIso');
       });
     });
   });
 
   describe('with type="relative"', () => {
-    beforeEach(() => {
-      component = shallow(<DateTime value={ defaultTimestamp } type="relative" />);
+    describe('and format="numeric"', () => {
+      beforeEach(() => {
+        component = shallow(<DateTime value={ defaultTimestamp } format="numeric" type="relative" />);
+      });
+
+      it('should wrap a FormattedRelative', () => {
+        expect(component.type().name).to.equal('FormattedRelative');
+      });
+
+      it('should set style to "numeric" by default', () => {
+        expect(component.prop('style')).to.equal('numeric');
+      });
     });
 
-    it('should wrap a FormattedRelative', () => {
-      expect(component.type().name).to.equal('FormattedRelative');
+    describe('and format="human"', () => {
+      it('should set style to "best fit" by if format="human"', () => {
+        component = shallow(<DateTime value={ defaultTimestamp } type="relative" format="human" />);
+        expect(component.prop('style')).to.equal('best fit');
+      });
+    });
+  });
+
+  describe('with type="time"', () => {
+    describe('and format="numeric"', () => {
+      beforeEach(() => {
+        component = shallow(<DateTime value={ defaultTimestamp } format="numeric" type="time" />);
+      });
+
+      it('should wrap a FormattedTime', () => {
+        expect(component.type().name).to.equal('FormattedTime');
+      });
+
+      it('should set hour, minute and second to "numeric"', () => {
+        expect(component.prop('hour')).to.equal('numeric');
+        expect(component.prop('minute')).to.equal('numeric');
+        expect(component.prop('second')).to.equal('numeric');
+      });
     });
 
-    it('should set style to "numeric" by default', () => {
-      expect(component.prop('style')).to.equal('numeric');
-    });
-
-    it('should set style to "best fit" by if format="human"', () => {
-      component = shallow(<DateTime value={ defaultTimestamp } type="relative" format="human" />);
-      expect(component.prop('style')).to.equal('best fit');
+    describe('and format="human"', () => {
+      it('should set hour and minute to "numeric" when format="human"', () => {
+        component = shallow(<DateTime value={ defaultTimestamp } format="human" type="time" />);
+        expect(component.prop('hour')).to.equal('numeric');
+        expect(component.prop('minute')).to.equal('numeric');
+      });
     });
   });
 });


### PR DESCRIPTION
- Add formats for time, numeric and human
- Show date by default if nothing else is specified for iso dates
- Remove setting default format to "numeric"
- Add more examples: Show type="time" and normal iso date
- Add comments to component headers
- Add tests to type="time"
- Add test to DateTimeIso where the default is now to only show the date
- Rewrite DateTime tests with respect to new default behavior where format is not set
