### PR TITLE
Watch source files when running TDD job

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build:watch": "npm run webpack -- --watch",
     "webpack": "webpack --progress --config webpack/config.babel.js",
     "test": "mocha --opts test/mocha.opts",
-    "test:tdd": "watch-run -i -p 'test/**/*.test.js, src/**/*' npm run test",
+    "test:tdd": "npm run test -- --watch --watch-extensions js,jsx",
     "coverage": "nyc --extension .jsx npm test",
     "precoveralls": "npm run coverage",
     "coveralls": "nyc report --reporter=text-lcov | coveralls",
@@ -110,7 +110,6 @@
     "sinon": "1.17.6",
     "sinon-chai": "2.8.0",
     "style-loader": "0.13.1",
-    "watch-run": "1.2.4",
     "webpack": "1.13.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "build": "npm-run-all env:prod webpack",
     "build:watch": "npm run webpack -- --watch",
     "webpack": "webpack --progress --config webpack/config.babel.js",
-    "test": "mocha",
-    "test:tdd": "npm test -- --watch",
+    "test": "mocha --opts test/mocha.opts",
+    "test:tdd": "watch-run -i -p 'test/**/*.test.js, src/**/*' npm run test",
     "coverage": "nyc --extension .jsx npm test",
     "precoveralls": "npm run coverage",
     "coveralls": "nyc report --reporter=text-lcov | coveralls",
@@ -110,6 +110,7 @@
     "sinon": "1.17.6",
     "sinon-chai": "2.8.0",
     "style-loader": "0.13.1",
+    "watch-run": "1.2.4",
     "webpack": "1.13.2"
   }
 }

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,6 @@
 --require babel-register
 --require test/static-assets-noop.js
 --require test/setup.mocha.js
+--colors
+
 --recursive


### PR DESCRIPTION
The current implementation came with two challenges on my computer:
1. Tests didn't rerun upon saving files in src/
2. Changes in src/ weren't adhered to when the watcher re-ran the
   tests

This should fix these challenges above
