### PR TITLE
Use en-dash instead of minus sign

### DIFF
--- a/src/components/development/development.jsx
+++ b/src/components/development/development.jsx
@@ -9,7 +9,7 @@ function renderSign(direction) {
     case 'positive':
       return (<span dangerouslySetInnerHTML={{ __html: '&plus; ' }} />);
     case 'negative':
-      return (<span dangerouslySetInnerHTML={{ __html: '&minus; ' }} />);
+      return (<span aria-label="&minus;" dangerouslySetInnerHTML={{ __html: '&ndash; ' }} />);
     default:
       return (<span />);
   }

--- a/src/components/number/number.jsx
+++ b/src/components/number/number.jsx
@@ -55,12 +55,19 @@ function Number({
   const minimumFractionDigits = getFractionDigits(tickDecimals, valueMinDecimals, valueDecimals);
   const maximumFractionDigits = getFractionDigits(tickDecimals, valueMaxDecimals, valueDecimals);
   const formattedNumber = formatNumber(value, { minimumFractionDigits, maximumFractionDigits });
+  const absFormattedNumber = formatNumber(Math.abs(value), { minimumFractionDigits, maximumFractionDigits });
+  const ariaSign = (value < 0) ? 'minus ' : '';
+  const sign = (value < 0) ? (<span dangerouslySetInnerHTML={{ __html: '&ndash; ' }} />) : null;
 
   return (
     <span title={formattedNumber} {...rest} className={classes} style={styles}>
       { renderAddon(prefix, prefixClass, prefixSeparator, prefixStyle, 'left') }
-      <span className={valueClass} style={valueStyle}>
-        {formattedNumber}
+      <span
+        className={valueClass}
+        style={valueStyle}
+        aria-label={`${ariaSign}${absFormattedNumber}`}
+      >
+        {sign}{absFormattedNumber}
       </span>
       { renderAddon(suffix, suffixClass, suffixSeparator, suffixStyle, 'right') }
     </span>

--- a/src/components/number/number.jsx
+++ b/src/components/number/number.jsx
@@ -56,7 +56,7 @@ function Number({
   const maximumFractionDigits = getFractionDigits(tickDecimals, valueMaxDecimals, valueDecimals);
   const formattedNumber = formatNumber(value, { minimumFractionDigits, maximumFractionDigits });
   const absFormattedNumber = formatNumber(Math.abs(value), { minimumFractionDigits, maximumFractionDigits });
-  const ariaSign = (value < 0) ? 'minus ' : '';
+  const ariaSign = (value < 0) ? '−' : '';
   const sign = (value < 0) ? (<span dangerouslySetInnerHTML={{ __html: '&ndash; ' }} />) : null;
 
   return (

--- a/src/components/percent/percent.examples.md
+++ b/src/components/percent/percent.examples.md
@@ -5,10 +5,10 @@ Basic examples:
         <Percent value={ 2.4444 } />
       </span>
       <span style={{marginRight: '2rem'}} title="Custom amount of decimals">
-        <Percent value={ 2.4444 } decimals={ 3 } />
+        <Percent value={ -1.4444 } decimals={ 3 } />
       </span>
       <span style={{marginRight: '2rem'}} title="With suffixSeparator">
-        <Percent value={ 2.4444 } decimals={ 2 } suffixSeparator=" " />
+        <Percent value={ -5.4444 } decimals={ 2 } suffixSeparator=" " />
       </span>
       <span style={{marginRight: '2rem'}} title="Another with suffixSeparator">
         <Percent value={ 1134.2334 } decimals={ 2 } suffixSeparator="____" />

--- a/src/components/value/value.examples.md
+++ b/src/components/value/value.examples.md
@@ -2,16 +2,16 @@ Simple examples:
 
     <div>
       <span style={{marginRight: '2rem'}} title="Only value supplied">
-        <Value value={ 2.4444 } />
+        <Value value={ -1.4444 } />
       </span>
       <span style={{marginRight: '2rem'}} title="Custom amount of decimals, set with decimals">
         <Value value={ 2.4444 } decimals={ 3 } />
       </span>
       <span style={{marginRight: '2rem'}} title="Custom amount of decimals, with min and max decimals">
-        <Value value={ 2.4444 } minDecimals={ 6 } maxDecimals={ 8 } />
+        <Value value={ -3.4444 } minDecimals={ 6 } maxDecimals={ 8 } />
       </span>
       <span style={{marginRight: '2rem'}} title="Custom amount of decimals, with min and max decimals">
-        <Value value={ 2.4444 } maxDecimals={ 1 } minDecimals={ 0 } />
+        <Value value={ -4.5678 } maxDecimals={ 1 } minDecimals={ 0 } />
       </span>
       <span style={{marginRight: '2rem'}} title="With prefix and prefixSeparator">
         <Value prefix="Value:" prefixSeparator=" " value={ 2.4444 } />

--- a/test/components/development.test.js
+++ b/test/components/development.test.js
@@ -45,8 +45,8 @@ describe('<Development />', () => {
     expect(component.prop('prefix').children).to.equals(undefined);
   });
 
-  it('should display minus prefix when value is < 0', () => {
-    const expected = { dangerouslySetInnerHTML: { __html: '&minus; ' } };
+  it('should display ndash prefix when value is < 0', () => {
+    const expected = { dangerouslySetInnerHTML: { __html: '&ndash; ' }, 'aria-label': '−' };
     const component = shallow(<Development value={-1} />);
     expect(component.prop('prefix').props).to.deep.equal(expected);
   });

--- a/test/components/number.test.js
+++ b/test/components/number.test.js
@@ -248,4 +248,29 @@ describe('<Number />', () => {
     const component = shallow(<Number.WrappedComponent intl={intl} value={1} suffix="(" suffixSeparator=":" />);
     expect(component.find(Addon).children().text()).to.deep.equal(':(');
   });
+
+  describe('a11y', () => {
+    let component;
+    beforeEach(() => {
+      component = shallow(<Number.WrappedComponent intl={intl} valueClass="value" value={-1} />);
+    });
+    it('should have an aria-label that matches the value', () => {
+      component = shallow(<Number.WrappedComponent intl={intl} valueClass="value" value={1} />);
+      const label = component.find('.value').prop('aria-label');
+      const value = component.find('.value').text();
+      expect(label).to.equal(value);
+    });
+    it('should always have a positive value', () => {
+      const value = component.find('.value').text();
+      expect(value).to.equal('1.00');
+    });
+    it('should have an aria-label with a negative value', () => {
+      const label = component.find('.value').prop('aria-label');
+      expect(label).to.contain('−');
+    });
+    it('should render a separate span with a minus for negative values', () => {
+      // eslint-disable-next-line
+      expect(component.find('.value > span').prop('dangerouslySetInnerHTML').__html).to.equal('&ndash; ');
+    });
+  });
 });


### PR DESCRIPTION
Using aria-label of "minus" to make screenreader work.

New look:
<img width="380" alt="screen shot 2017-05-16 at 12 27 23" src="https://cloud.githubusercontent.com/assets/1844083/26102046/aeb98872-3a33-11e7-95bd-5052e238f1dd.png">
