### PR TITLE
Include PropTypes in the correct way

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "test"
   },
   "scripts": {
+    "dev": "run-s start",
     "start": "run-s docs:watch",
     "analyze": "ANALYZE=true run-s webpack",
     "clean:docs": "rimraf docs",
@@ -117,5 +118,8 @@
     "style-loader": "^0.18.0",
     "webpack": "^2.3.3",
     "webpack-bundle-analyzer": "^2.3.0"
+  },
+  "dependencies": {
+    "prop-types": "^15.5.10"
   }
 }

--- a/src/components/addon/addon.jsx
+++ b/src/components/addon/addon.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 /**

--- a/src/components/currency/currency.jsx
+++ b/src/components/currency/currency.jsx
@@ -46,7 +46,7 @@ Currency.defaultProps = {
 };
 
 Currency.propTypes = {
-  value: PropTypes.any.isRequired,
+  value: PropTypes.any.isRequired, // eslint-disable-line
   /**
     Syntactic sugar for `suffix` (either one can be used)
   */

--- a/src/components/currency/currency.jsx
+++ b/src/components/currency/currency.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import Number from '../number/number';
 import variables from '../../variables';
 
@@ -45,7 +46,7 @@ Currency.defaultProps = {
 };
 
 Currency.propTypes = {
-  value: PropTypes.any.isRequired, // eslint-disable-line
+  value: PropTypes.any.isRequired,
   /**
     Syntactic sugar for `suffix` (either one can be used)
   */

--- a/src/components/date-time-iso/date-time-iso.jsx
+++ b/src/components/date-time-iso/date-time-iso.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import isoDate from './iso-date';
 
 /**

--- a/src/components/date-time/date-time.jsx
+++ b/src/components/date-time/date-time.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { FormattedDate, FormattedTime, FormattedRelative } from 'react-intl';
 import DateTimeIso from '../date-time-iso/date-time-iso';
 import formats from './date-time-formats';

--- a/src/components/development/development.jsx
+++ b/src/components/development/development.jsx
@@ -72,7 +72,7 @@ export default function Development({
 
 Development.propTypes = {
   className: PropTypes.string,
-  value: PropTypes.any.isRequired,
+  value: PropTypes.any.isRequired, // eslint-disable-line
   decimals: PropTypes.number,
   type: PropTypes.oneOf(['number', 'currency', 'percentage']),
   direction: PropTypes.oneOf(['positive', 'negative', 'neutral']),

--- a/src/components/development/development.jsx
+++ b/src/components/development/development.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import NumberComponent from '../number/number';
 import CurrencyComponent from '../currency/currency';
@@ -71,7 +72,7 @@ export default function Development({
 
 Development.propTypes = {
   className: PropTypes.string,
-  value: PropTypes.any.isRequired, // eslint-disable-line
+  value: PropTypes.any.isRequired,
   decimals: PropTypes.number,
   type: PropTypes.oneOf(['number', 'currency', 'percentage']),
   direction: PropTypes.oneOf(['positive', 'negative', 'neutral']),

--- a/src/components/freshness-indicator/freshness-indicator.jsx
+++ b/src/components/freshness-indicator/freshness-indicator.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { Icon, variables, Tooltip } from 'nordnet-ui-kit';
 import TooltipTimestamp from './tooltip-timestamp';
 import TooltipDelay from './tooltip-delay';

--- a/src/components/freshness-indicator/tooltip-delay-content.jsx
+++ b/src/components/freshness-indicator/tooltip-delay-content.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { FormattedMessage, defineMessages } from 'react-intl';
 
 const messages = defineMessages({

--- a/src/components/freshness-indicator/tooltip-delay.jsx
+++ b/src/components/freshness-indicator/tooltip-delay.jsx
@@ -1,6 +1,6 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import TooltipDelayContent from './tooltip-delay-content';
-
 
 function TooltipDelay(props) {
   return (

--- a/src/components/freshness-indicator/tooltip-timestamp.jsx
+++ b/src/components/freshness-indicator/tooltip-timestamp.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { FormattedMessage, defineMessages } from 'react-intl';
 import DateTime from '../date-time/date-time';
 import { numberIsFinite } from '../../utils';

--- a/src/components/icon-row/icon-row.jsx
+++ b/src/components/icon-row/icon-row.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import RowInfo from './row-info';
 
 const IconRow = ({

--- a/src/components/icon-row/row-info.jsx
+++ b/src/components/icon-row/row-info.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 const RowInfo = ({ leftItem, rightItem, alignBaseline }) => {
   const styles = {

--- a/src/components/number/number.jsx
+++ b/src/components/number/number.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { injectIntl, intlShape } from 'react-intl';
 import classNames from 'classnames';
 import Addon from '../addon/addon';
@@ -77,7 +78,7 @@ function Number({
 Number.propTypes = {
   className: PropTypes.string,
   style: PropTypes.object,
-  value: PropTypes.any.isRequired, // eslint-disable-line
+  value: PropTypes.any.isRequired,
   valueClass: PropTypes.string,
   valueDecimals: PropTypes.number,
   valueMaxDecimals: PropTypes.number,

--- a/src/components/number/number.jsx
+++ b/src/components/number/number.jsx
@@ -78,7 +78,7 @@ function Number({
 Number.propTypes = {
   className: PropTypes.string,
   style: PropTypes.object,
-  value: PropTypes.any.isRequired,
+  value: PropTypes.any.isRequired, // eslint-disable-line
   valueClass: PropTypes.string,
   valueDecimals: PropTypes.number,
   valueMaxDecimals: PropTypes.number,

--- a/src/components/percent/percent.jsx
+++ b/src/components/percent/percent.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import Number from '../number/number';
 
 /**
@@ -33,7 +34,7 @@ Percent.defaultProps = {
 };
 
 Percent.propTypes = {
-  value: PropTypes.any.isRequired, // eslint-disable-line
+  value: PropTypes.any.isRequired,
   decimals: PropTypes.number,
   /**
     Default is an empty string (`''`)

--- a/src/components/percent/percent.jsx
+++ b/src/components/percent/percent.jsx
@@ -34,7 +34,7 @@ Percent.defaultProps = {
 };
 
 Percent.propTypes = {
-  value: PropTypes.any.isRequired,
+  value: PropTypes.any.isRequired, // eslint-disable-line
   decimals: PropTypes.number,
   /**
     Default is an empty string (`''`)

--- a/src/components/value/value.jsx
+++ b/src/components/value/value.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import Number from '../number/number';
 
 /**
@@ -29,7 +30,7 @@ Value.defaultProps = {
 };
 
 Value.propTypes = {
-  value: PropTypes.any.isRequired, // eslint-disable-line
+  value: PropTypes.any.isRequired,
   decimals: PropTypes.number,
   maxDecimals: PropTypes.number,
   minDecimals: PropTypes.number,

--- a/src/components/value/value.jsx
+++ b/src/components/value/value.jsx
@@ -30,7 +30,7 @@ Value.defaultProps = {
 };
 
 Value.propTypes = {
-  value: PropTypes.any.isRequired,
+  value: PropTypes.any.isRequired, // eslint-disable-line
   decimals: PropTypes.number,
   maxDecimals: PropTypes.number,
   minDecimals: PropTypes.number,

--- a/styleguide/wrapper.jsx
+++ b/styleguide/wrapper.jsx
@@ -1,5 +1,6 @@
 import 'babel-polyfill';
 import React from 'react';
+import PropTypes from 'prop-types';
 import { addLocaleData, IntlProvider } from 'react-intl';
 import { Input } from 'nordnet-ui-kit';
 
@@ -71,7 +72,7 @@ class Wrapper extends React.Component {
 }
 
 Wrapper.propTypes = {
-  children: React.PropTypes.node.isRequired,
+  children: PropTypes.node.isRequired,
 };
 
 export default Wrapper;

--- a/test/hocs/on-click-outside-dummy-component.jsx
+++ b/test/hocs/on-click-outside-dummy-component.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import onClickOutside from '../../src/hocs/on-click-outside/on-click-outside';
 
 class Dummy extends React.Component {


### PR DESCRIPTION
We get warnings because we used to to include PropTypes from the `react` package, but this is deprecated.

This should fix that.

Fixes #629 