### PR TITLE
Feat/allow overriding colors

### DIFF
--- a/src/components/development/development.jsx
+++ b/src/components/development/development.jsx
@@ -25,6 +25,10 @@ function getDirection(value) {
   return 'neutral';
 }
 
+function getDirectionColor(direction, colors) {
+  return colors[direction];
+}
+
 function getDecimalProps(type, decimals, maxDecimals, minDecimals) {
   const isNumber = type === 'number';
   return {
@@ -37,7 +41,19 @@ function getDecimalProps(type, decimals, maxDecimals, minDecimals) {
 /**
   This is the `<Development /> component`
 */
-export default function Development({ value, decimals, type, direction, className, maxDecimals, minDecimals, ...rest }) {
+export default function Development({
+  positiveColor: positive,
+  negativeColor: negative,
+  neutralColor: neutral,
+  value,
+  decimals,
+  type,
+  direction,
+  className,
+  maxDecimals,
+  minDecimals,
+  ...rest
+}) {
   const components = {
     currency: CurrencyComponent,
     percentage: PercentComponent,
@@ -46,6 +62,14 @@ export default function Development({ value, decimals, type, direction, classNam
   const developmentDirection = direction || getDirection(value);
   const Component = components[type] || components.number;
   const classes = classNames(`number--${developmentDirection}`, className);
+  const style = {
+    ...rest.style,
+    color: getDirectionColor(developmentDirection, {
+      positive,
+      negative,
+      neutral,
+    }),
+  };
 
   const decimalProps = getDecimalProps(type, decimals, maxDecimals, minDecimals);
 
@@ -53,6 +77,7 @@ export default function Development({ value, decimals, type, direction, classNam
     <Component
       {...rest}
       {...decimalProps}
+      style={style}
       className={classes}
       value={Math.abs(parseFloat(value))}
       prefix={renderSign(developmentDirection)}
@@ -69,8 +94,14 @@ Development.propTypes = {
   direction: PropTypes.oneOf(['positive', 'negative', 'neutral']),
   maxDecimals: PropTypes.number,
   minDecimals: PropTypes.number,
+  positiveColor: PropTypes.string,
+  neutralColor: PropTypes.string,
+  negativeColor: PropTypes.string,
 };
 
 Development.defaultProps = {
   type: 'number',
+  positiveColor: 'inherit',
+  neutralColor: 'inherit',
+  negativeColor: 'inherit',
 };

--- a/src/components/development/development.md
+++ b/src/components/development/development.md
@@ -60,3 +60,20 @@ Advanced examples:
         <Development value={ 42.3444 } direction="neutral"/>
       </span>
     </div>
+
+Override colors examples:
+
+    const customColors = {
+      positiveColor: 'cornflowerblue',
+      negativeColor: 'tomato',
+      neutralColor: 'rebeccapurple',
+    };
+
+    <div>
+      <span style={{marginRight: '2rem'}}>
+        <Development value={ 9.2 } {...customColors} />
+      </span>
+      <span style={{marginRight: '2rem'}}>
+        <Development value={ -11.4 } {...customColors} />
+      </span>
+    </div>

--- a/test/components/development.test.js
+++ b/test/components/development.test.js
@@ -104,4 +104,33 @@ describe('<Development />', () => {
       expect(passedMinDecimals).to.equal(minDecimals);
     });
   });
+
+  describe('Custom colors', () => {
+    it('should default to color: "inherit"', () => {
+      const component = shallow(<Development value={0} type="number" />);
+      const { color } = component.find(Number).prop('style');
+      expect(color).to.equal('inherit');
+    });
+
+    it('should be possible to override positive color', () => {
+      const customColor = 'green';
+      const component = shallow(<Development value={1} type="number" positiveColor={customColor} />);
+      const { color } = component.find(Number).prop('style');
+      expect(color).to.equal(customColor);
+    });
+
+    it('should be possible to override negative color', () => {
+      const customColor = 'red';
+      const component = shallow(<Development value={-1} type="number" negativeColor={customColor} />);
+      const { color } = component.find(Number).prop('style');
+      expect(color).to.equal(customColor);
+    });
+
+    it('should be possible to override neutral color', () => {
+      const customColor = 'orange';
+      const component = shallow(<Development value={0} type="number" neutralColor={customColor} />);
+      const { color } = component.find(Number).prop('style');
+      expect(color).to.equal(customColor);
+    });
+  });
 });


### PR DESCRIPTION
Fixes #581 

Heavily inspired by #581, but this also allows extending style instead of overriding. Also the other branch had a lot of junk in it.