### PR TITLE
fix(DateTime): add useDashForInvalidValues parameter

### DIFF
--- a/src/components/date-time/date-time.jsx
+++ b/src/components/date-time/date-time.jsx
@@ -3,11 +3,23 @@ import React from 'react';
 import { FormattedDate, FormattedTime, FormattedRelative } from 'react-intl';
 import DateTimeIso from '../date-time-iso/date-time-iso';
 import formats from './date-time-formats';
+import { valuePropType } from '../../utils';
+
+const isInvalid = value =>
+  typeof value === 'undefined' || value === null || String(value) === 'Invalid Date' || String(new Date(value)) === 'Invalid Date';
 
 /**
   This is the `<DateTime /> component`
 */
-function DateTime({ value, format, type, iso, ...rest }) {
+function DateTime({ value, format, type, iso, useDashForInvalidValues, ...rest }) {
+  if (useDashForInvalidValues && isInvalid(value)) {
+    return (
+      <span {...rest} aria-hidden="true">
+        –
+      </span>
+    );
+  }
+
   if (iso) {
     return <DateTimeIso value={value} {...rest} />;
   }
@@ -26,6 +38,7 @@ DateTime.defaultProps = {
   format: 'numeric',
   iso: false,
   type: 'date',
+  useDashForInvalidValues: false,
 };
 
 DateTime.propTypes = {
@@ -37,8 +50,9 @@ DateTime.propTypes = {
   /**
     A timestamp.
   */
-  value: PropTypes.oneOfType([PropTypes.number, PropTypes.instanceOf(Date)]).isRequired,
+  value: valuePropType,
   type: PropTypes.oneOf(['date', 'time', 'relative']),
+  useDashForInvalidValues: PropTypes.bool,
 };
 
 export default DateTime;

--- a/test/components/date-time.test.js
+++ b/test/components/date-time.test.js
@@ -88,4 +88,24 @@ describe('<DateTime />', () => {
       });
     });
   });
+
+  describe('with useDashForInvalidValues', () => {
+    it('should render dash for invalid date values', () => {
+      const invalidDates = [undefined, null, 'foo'];
+      invalidDates.forEach(invalidDate => {
+        component = shallow(<DateTime value={invalidDate} useDashForInvalidValues />);
+        expect(component.type()).to.equal('span');
+        expect(component.text()).to.equal('–');
+      });
+    });
+
+    it('should not render dash for valid date values', () => {
+      const validDates = [defaultTimestamp, 0, new Date(), '2019-02-14'];
+      validDates.forEach(validDate => {
+        component = shallow(<DateTime value={validDate} useDashForInvalidValues />);
+        expect(component.type().name).to.equal('FormattedDate');
+        expect(component.text()).to.not.equal('–');
+      });
+    });
+  });
 });


### PR DESCRIPTION
If parameter useDashForInvalidValues is set, DateTime will now display a dash instead of "Invalid Date".